### PR TITLE
fix useEffect re-render loop in setTimeout

### DIFF
--- a/src/Callback.js
+++ b/src/Callback.js
@@ -13,7 +13,7 @@ const CallbackComponent = () => {
   const [time, setTime] = useState(new Date());
   const [count, setCount] = useState(1);
   useEffect(() => {
-    const timer = setTimeout(setTime(new Date()), 1000);
+    const timer = setTimeout(() => setTime(new Date()), 1000);
     return () => clearTimeout(timer);
   });
 

--- a/src/Effect.js
+++ b/src/Effect.js
@@ -4,7 +4,7 @@ const EffectComponent = () => {
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
-    const timer = setTimeout(setTime(new Date()), 1000);
+    const timer = setTimeout(() => setTime(new Date()), 1000);
     return () => clearTimeout(timer);
   });
 


### PR DESCRIPTION
<-- _I wasn't sure if I should open an issue/PR here or in the main course repo._ -->

The `useEffect()` example in _Intermediate React v2_ causes a (rapid) infinite render loop.
_Edit:_ Same pattern in `useCallback()` example as well.

The `setTime()` updater is called _in_ useEffect when evaluating the arguments to `setTimeout()`, rather than after the 1000ms delay. This causes the component to immediately re-render, continuing the loop.

Moving the call to `setTime()` into an anonymous function corrects the behavior.

See [this gist](https://gist.github.com/connorrose/c477efbe4307e01de75d317efcc6fada) for an instrumented example.
